### PR TITLE
Add a Quick Settings Tile to control/monitor service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -90,7 +90,7 @@
         <service android:name=".TileMainService"
             android:exported="true"
             android:label="@string/app_name"
-            android:icon="@drawable/ic_launcher_foreground"
+            android:icon="@drawable/ic_notification"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
 
             <meta-data android:name="android.service.quicksettings.TOGGLEABLE_TILE"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,6 +73,9 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
+            </intent-filter>
         </activity>
 
         <receiver android:name=".MainService$StopSvcReceiver"
@@ -83,6 +86,20 @@
         </receiver>
 
         <service android:name=".MainService" />
+
+        <service android:name=".TileMainService"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:icon="@drawable/ic_launcher_foreground"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+
+            <meta-data android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="true" />
+
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/slowscript/warpinator/MainService.java
+++ b/app/src/main/java/slowscript/warpinator/MainService.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.List;
@@ -456,7 +457,14 @@ public class MainService extends Service {
     }
 
     public void notifyDeviceCountUpdate() {
-        int count = remotes.size();
+        int count = 0;
+        Collection<Remote> remotes = MainService.remotes.values();
+        for (Remote remote : remotes) {
+            if (remote.status == Remote.RemoteStatus.CONNECTED) {
+                count++;
+            }
+        }
+
         for (WeakReference<RemoteCountObserver> observer : remoteCountObservers) {
             RemoteCountObserver obs = observer.get();
             if (obs != null) {

--- a/app/src/main/java/slowscript/warpinator/MainService.java
+++ b/app/src/main/java/slowscript/warpinator/MainService.java
@@ -28,11 +28,11 @@ import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 
 import java.io.File;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Timer;
@@ -63,6 +63,7 @@ public class MainService extends Service {
 
     public static MainService svc;
     public static ConcurrentHashMap<String, Remote> remotes = new ConcurrentHashMap<>();
+    public static final ArrayList<WeakReference<RemoteCountObserver>> remoteCountObservers = new ArrayList<>();
     public static List<String> remotesOrder = Collections.synchronizedList(new ArrayList<>());
     SharedPreferences prefs;
     ExecutorService executor = Executors.newCachedThreadPool();
@@ -81,7 +82,13 @@ public class MainService extends Service {
     @Nullable
     @Override
     public IBinder onBind(Intent intent) {
-        return null;
+        return new MainServiceBinder(this);
+    }
+
+    @Override
+    public boolean onUnbind(Intent intent) {
+        remoteCountObservers.clear();
+        return false;
     }
 
     @Override
@@ -132,6 +139,11 @@ public class MainService extends Service {
         if(prefs.getBoolean("background", true)) {
             Notification notification = createForegroundNotification();
             startForeground(SVC_NOTIFICATION_ID, notification);
+        }
+
+        // Notify the tile service that MainService just started, so it can attempt to bind
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            TileMainService.requestListeningState(this);
         }
 
         return START_STICKY;
@@ -441,6 +453,33 @@ public class MainService extends Service {
         if (prefs == null)
             return false;
         return prefs.getBoolean("autoStop", true) && !prefs.getBoolean("bootStart", false);
+    }
+
+    public void notifyDeviceCountUpdate() {
+        int count = remotes.size();
+        for (WeakReference<RemoteCountObserver> observer : remoteCountObservers) {
+            RemoteCountObserver obs = observer.get();
+            if (obs != null) {
+                obs.onDeviceCountChange(count);
+            }
+        }
+    }
+
+    public DisposableRemoteCountObserver observeDeviceCount(RemoteCountObserver observer) {
+        remoteCountObservers.add(new WeakReference<>(observer));
+        observer.onDeviceCountChange(remotes.size());
+
+        return () -> {
+            remoteCountObservers.remove(new WeakReference<>(observer));
+        };
+    }
+
+    public interface RemoteCountObserver {
+        void onDeviceCountChange(int newCount);
+    }
+
+    public interface DisposableRemoteCountObserver {
+        void dispose();
     }
 
     public static class StopSvcReceiver extends BroadcastReceiver {

--- a/app/src/main/java/slowscript/warpinator/MainServiceBinder.java
+++ b/app/src/main/java/slowscript/warpinator/MainServiceBinder.java
@@ -1,0 +1,16 @@
+package slowscript.warpinator;
+
+import android.os.Binder;
+
+public class MainServiceBinder extends Binder {
+
+    private final MainService service;
+
+    public MainServiceBinder(MainService service) {
+        this.service = service;
+    }
+
+    public MainService getService() {
+        return service;
+    }
+}

--- a/app/src/main/java/slowscript/warpinator/Server.java
+++ b/app/src/main/java/slowscript/warpinator/Server.java
@@ -349,6 +349,7 @@ public class Server {
     void addRemote(Remote remote) {
         //Add to remotes list
         MainService.remotes.put(remote.uuid, remote);
+        svc.notifyDeviceCountUpdate();
         if (favorites.contains(remote.uuid)) //Add favorites at the beginning
             MainService.remotesOrder.add(0, remote.uuid);
         else

--- a/app/src/main/java/slowscript/warpinator/TileMainService.java
+++ b/app/src/main/java/slowscript/warpinator/TileMainService.java
@@ -1,0 +1,142 @@
+package slowscript.warpinator;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.Build;
+import android.os.IBinder;
+import android.service.quicksettings.Tile;
+import android.service.quicksettings.TileService;
+
+import androidx.annotation.RequiresApi;
+
+@RequiresApi(api = Build.VERSION_CODES.N)
+public class TileMainService extends TileService implements MainService.RemoteCountObserver {
+    private Intent serviceIntent;
+    private ServiceConnection serviceConnection;
+    private MainServiceBinder binder;
+    private MainService.DisposableRemoteCountObserver unregisterObserver = null;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        serviceIntent = new Intent(this, MainService.class);
+    }
+
+    @Override
+    public void onStartListening() {
+        super.onStartListening();
+        boolean isRunning = Utils.isMyServiceRunning(this, MainService.class);
+        updateTile(isRunning);
+        if (isRunning && binder == null) {
+            joinService();
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        if (serviceConnection != null) {
+            unbindService(serviceConnection);
+            serviceConnection = null;
+        }
+        if (unregisterObserver != null) {
+            unregisterObserver.dispose();
+            unregisterObserver = null;
+        }
+        binder = null;
+        super.onDestroy();
+    }
+
+    @Override
+    public void onClick() {
+        super.onClick();
+        switch (getQsTile().getState()) {
+            case Tile.STATE_ACTIVE:
+                stopService();
+                break;
+            case Tile.STATE_INACTIVE:
+                // Activating Warpinator requires unlocking the device first
+                unlockAndRun(this::startService);
+                break;
+        }
+    }
+
+    void updateTile(boolean active) {
+        Tile tile = getQsTile();
+        if (active) {
+            tile.setState(Tile.STATE_ACTIVE);
+        } else {
+            tile.setState(Tile.STATE_INACTIVE);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                tile.setSubtitle(null);
+            }
+        }
+        tile.updateTile();
+    }
+
+    private void updateBoundService(MainServiceBinder binder) {
+        this.binder = binder;
+        if (binder == null) {
+            serviceConnection = null;
+            if (unregisterObserver != null) {
+                unregisterObserver.dispose();
+                unregisterObserver = null;
+            }
+            updateTile(false);
+        } else {
+            unregisterObserver = this.binder.getService().observeDeviceCount(this);
+            updateTile(true);
+        }
+    }
+
+    private void startService() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(serviceIntent);
+        } else {
+            startService(serviceIntent);
+        }
+        joinService();
+    }
+
+    private void joinService() {
+        bindService(serviceIntent, serviceConnection = new ServiceConnection() {
+            @Override
+            public void onServiceConnected(ComponentName componentName, IBinder iBinder) {
+                updateBoundService((MainServiceBinder) iBinder);
+            }
+
+            @Override
+            public void onServiceDisconnected(ComponentName componentName) {
+                updateBoundService(null);
+            }
+        }, 0);
+    }
+
+    private void stopService() {
+        updateTile(false);
+        updateBoundService(null);
+        Intent stopIntent = new Intent(this, MainService.StopSvcReceiver.class);
+        stopIntent.setAction(MainService.ACTION_STOP);
+        sendBroadcast(stopIntent);
+    }
+
+    @Override
+    public void onDeviceCountChange(int newCount) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            Tile tile = getQsTile();
+            if (newCount > 0 && tile.getState() == Tile.STATE_ACTIVE) {
+                tile.setSubtitle(getString(R.string.qs_discovered_count, newCount));
+            } else {
+                // If there are no discovered remotes, don't mention them.
+                // This should fall back to displaying the state of the tile ("On").
+                tile.setSubtitle(null);
+            }
+            tile.updateTile();
+        }
+    }
+
+    public static void requestListeningState(Context context) {
+        requestListeningState(context, new ComponentName(context, TileMainService.class));
+    }
+}

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -133,5 +133,5 @@
     <string name="initiate_connection">Lancer la connexion</string>
     <string name="manual_connect_text">Analysez le code QR ci-dessus avec une application de caméra et ouvrez le lien ou bien utilisez l\'adresse suivante pour lancer la connexion depuis l\'autre appareil :</string>
     <string name="manual_connection">Connexion manuelle</string>
-    <string name="qs_discovered_count">%d à portée</string>
+    <string name="qs_discovered_count">%d connectés</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -133,4 +133,5 @@
     <string name="initiate_connection">Lancer la connexion</string>
     <string name="manual_connect_text">Analysez le code QR ci-dessus avec une application de caméra et ouvrez le lien ou bien utilisez l\'adresse suivante pour lancer la connexion depuis l\'autre appareil :</string>
     <string name="manual_connection">Connexion manuelle</string>
+    <string name="qs_discovered_count">%d à portée</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,4 +136,5 @@
         <item>Finished</item>
         <item>Finished with errors (tap to view)</item>
     </string-array>
+    <string name="qs_discovered_count">%d in range</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="clear_transfers">Clear finished transfers</string>
     <string name="manual_connect_text">Scan the QR code above with a camera app and open the link or use the following address to initiate the connection from the other device:</string>
     <string name="initiate_connection">Initiate connection</string>
+    <string name="qs_discovered_count">%d connected</string>
     <string-array name="connected_states">
         <item>Connected</item>
         <item>Disconnected</item>
@@ -136,5 +137,4 @@
         <item>Finished</item>
         <item>Finished with errors (tap to view)</item>
     </string-array>
-    <string name="qs_discovered_count">%d in range</string>
 </resources>


### PR DESCRIPTION
Adds a Quick Settings Tile to quickly toggle the service state and monitor its state. Most context can be found in #135.

A lot of things in the PR may be imperfect. Feel free to ask for changes.

<p align="center">
<img src="https://github.com/slowscript/warpinator-android/assets/46636609/f4261be8-bce0-4c63-8fcb-3396983d7041" width="50%">
</p>